### PR TITLE
fb_smc_speedup: Performance optimize on SMC grid

### DIFF
--- a/model/ftn/w3gdatmd.ftn
+++ b/model/ftn/w3gdatmd.ftn
@@ -1172,6 +1172,12 @@
 !/ Data aliasing for structure SICP(S)
 !/IS1      REAL, POINTER           :: IS1C1, IS1C2
 !/
+!/ Data duplicated for better performance 
+!/SMC        INTEGER, POINTER      :: IJKCel3(:), IJKCel4(:), &
+!/SMC                                 IJKVFc5(:), IJKVFc6(:), &
+!/SMC                                 IJKUFc5(:), IJKUFc6(:)
+!/
+
       CONTAINS
 !/ ------------------------------------------------------------------- /
       SUBROUTINE W3NMOD ( NUMBER, NDSE, NDST, NAUX )
@@ -1493,6 +1499,10 @@
 !/SMC                 GRIDS(IMOD)%CLATF(MVFc),        &
 !/SMC                 STAT=ISTAT                      )
 !/SMC      CHECK_ALLOC_STATUS ( ISTAT )
+!/SMC      ALLOCATE ( IJKCel3(-9:MCel), IJKCel4(-9:MCel), &
+!/SMC                 IJKVFc5(MVFc), IJKVFc6(MVFc),  &
+!/SMC                 IJKUFc5(MUFc), IJKUFc6(MUFc),  &
+!/SMC                 STAT=ISTAT)
 !
 !/ARC      ALLOCATE ( GRIDS(IMOD)%ICLBAC(MBAC),       &
 !/ARC                 GRIDS(IMOD)%ANGARC(MARC),       &

--- a/model/ftn/w3iogrmd.ftn
+++ b/model/ftn/w3iogrmd.ftn
@@ -754,6 +754,18 @@
 !/SMC                     NLvCel, NLvUFc, NLvVFc
 !/SMC          READ (NDSM,END=801,ERR=802,IOSTAT=IERR)                &
 !/SMC                     IJKCel, IJKUFc, IJKVFc
+!/SMC          DO J=lbound(IJKCel,2), ubound(IJKCel,2)
+!/SMC            IJKCel3(J) = IJKCel(3,J)
+!/SMC            IJKCel4(J) = IJKCel(4,J)
+!/SMC          END DO
+!/SMC          DO J=lbound(IJKVFc,2), ubound(IJKVFc,2)
+!/SMC            IJKVFc5(J) = IJKVFc(5,J)
+!/SMC            IJKVFc6(J) = IJKVFc(6,J)
+!/SMC          END DO
+!/SMC          DO J=lbound(IJKUFc,2), ubound(IJKUFc,2)
+!/SMC            IJKUFc5(J) = IJKUFc(5,J)
+!/SMC            IJKUFc6(J) = IJKUFc(6,J)
+!/SMC          END DO
 !/ARC          READ (NDSM,END=801,ERR=802,IOSTAT=IERR)                &
 !/ARC                     ICLBAC 
 !/ARC          READ (NDSM,END=801,ERR=802,IOSTAT=IERR)                &

--- a/model/ftn/w3psmcmd.ftn
+++ b/model/ftn/w3psmcmd.ftn
@@ -223,6 +223,8 @@
       USE W3GDATMD, ONLY: NK, NTH, DTH, XFR, ESIN, ECOS, SIG, NX, NY,  &
                           NSEA, SX, SY, MAPSF, FUNO3, FVERG,           &
                           IJKCel, IJKUFc, IJKVFc, NCel, NUFc, NVFc,    &
+                          IJKCel3, IJKCel4,                            &
+                          IJKVFc5, IJKVFc6,IJKUFc5,IJKUFc6,            &
                           NLvCel, NLvUFc, NLvVFc, NRLv, MRFct,         &
                           DTCFL, CLATS, DTME, CLATMN, CTRNX, CTRNY 
 !/ARC      USE W3GDATMD, ONLY: NGLO, ANGARC 
@@ -441,8 +443,8 @@
 !  Store conservative flux in FCNt advective one in AFCN
 !/OMPG/!$OMP Parallel DO Private(i, M, N, FUTRN)
            DO i=1, NUFc
-              M=IJKUFc(5,i)
-              N=IJKUFc(6,i)
+              M=IJKUFc5(i)
+              N=IJKUFc6(i)
               FUTRN = FUMD(i)*ULCFLX(i) - FUDIFX(i)
 
 !! Add sub-grid transparency for input flux update.  JGLi16May2011
@@ -493,8 +495,8 @@
 !  Note ULCFLX has been divided by the cell size inside SMCxUNO2.
 !/OMPG/!$OMP Parallel DO Private(n)
            DO n=1, NSEA
-              CQA(n)=CQ(n) + FCNt(n)/FLOAT(IJKCel(3,n))
-              CQ (n)=CQ(n) + AFCN(n)/FLOAT(IJKCel(3,n))
+              CQA(n)=CQ(n) + FCNt(n)/FLOAT(IJKCel3(n))
+              CQ (n)=CQ(n) + AFCN(n)/FLOAT(IJKCel3(n))
            ENDDO
 !/OMPG/!$OMP END Parallel DO
 
@@ -509,8 +511,8 @@
 
 !/OMPG/!$OMP Parallel DO Private(j, M, N, FVTRN)
            DO j=1, NVFc
-              M=IJKVFc(5,j)
-              N=IJKVFc(6,j)
+              M=IJKVFc5(j)
+              N=IJKVFc6(j)
               FVTRN = FVMD(j)*VLCFLY(j) - FVDIFY(j)
 
 !! Add sub-grid transparency for input flux update.  JGLi16May2011
@@ -551,7 +553,7 @@
 !! One cosine factor is also needed to be divided for SMC grid
 !/OMPG/!$OMP Parallel DO Private(n)
            DO n=1, NSEA
-              CQ(n)=CQA(n) + BCNt(n)/( CLATS(n)*FLOAT(IJKCel(3,n)) )
+              CQ(n)=CQA(n) + BCNt(n)/( CLATS(n)*FLOAT(IJKCel3(n)) )
            ENDDO
 !/OMPG/!$OMP END Parallel DO
 !/ARC  !Li  Polar cell needs a special area factor, one-level case.
@@ -595,8 +597,8 @@
 !  Store fineset level conservative flux in FCNt advective one in AFCN
 !/OMPG/!$OMP Parallel DO Private(i, L, M, FUTRN)
            DO i=iuf, juf 
-              L=IJKUFc(5,i)
-              M=IJKUFc(6,i)
+              L=IJKUFc5(i)
+              M=IJKUFc6(i)
               FUTRN = FUMD(i)*ULCFLX(i) - FUDIFX(i)
 !! Replace CRITICAL with ATOMIC.  JGLi15Jan2019
 !! !$OMP CRITICAL 
@@ -642,8 +644,8 @@
 !  Also divided by another cell x-size as UCFL is in size-1 unit.
 !/OMPG/!$OMP Parallel DO Private(n)
            DO n=icl, jcl 
-              CQA(n)=CQ(n) + FCNt(n)/FLOAT( IJKCel(3, n)*IJKCel(4, n) )
-              CQ (n)=CQ(n) + AFCN(n)/FLOAT( IJKCel(3, n)*IJKCel(4, n) )
+              CQA(n)=CQ(n) + FCNt(n)/FLOAT( IJKCel3(n)*IJKCel4(n) )
+              CQ (n)=CQ(n) + AFCN(n)/FLOAT( IJKCel3(n)*IJKCel4(n) )
               FCNt(n)=0.0
               AFCN(n)=0.0
            ENDDO
@@ -660,8 +662,8 @@
 !  Store conservative flux in BCNt
 !/OMPG/!$OMP Parallel DO Private(j, L, M, FVTRN)
            DO j=ivf, jvf 
-              L=IJKVFc(5,j)
-              M=IJKVFc(6,j)
+              L=IJKVFc5(j)
+              M=IJKVFc6(j)
               FVTRN = FVMD(j)*VLCFLY(j) - FVDIFY(j)
 !! Replace CRITICAL with ATOMIC.  JGLi15Jan2019
 !! !$OMP CRITICAL 
@@ -703,7 +705,7 @@
 !/OMPG/!$OMP Parallel DO Private(n)
            DO n=icl, jcl
               CQ(n)=CQA(n) + BCNt(n)/( CLATS(n)*            &
-      &             FLOAT( IJKCel(3, n)*IJKCel(4, n) ) )
+      &             FLOAT( IJKCel3(n)*IJKCel4(n) ) )
               BCNt(n)=0.0
            ENDDO
 !/OMPG/!$OMP END Parallel DO
@@ -1089,7 +1091,8 @@
 !!Li         CALL SMCxUNO2(iuf, juf, CQ, UCFL, ULCFLX, DNND, FUMD, FUDIFX, FMR)
 
          USE CONSTANTS
-         USE W3GDATMD, ONLY: NCel, MRFct, NUFc, IJKCel, IJKUFc, CLATS
+         USE W3GDATMD, ONLY: NCel, MRFct, NUFc, IJKCel, IJKUFc, CLATS, &
+                             IJKCel3, IJKCel4
          USE W3ODATMD, ONLY: NDSE, NDST 
 
          IMPLICIT NONE
@@ -1127,8 +1130,8 @@
            N=IJKUFc(7,i)
 
 !    Face bounding cell lengths and central gradient
-           CNST2=FLOAT( IJKCel(3,L) )
-           CNST3=FLOAT( IJKCel(3,M) )
+           CNST2=FLOAT( IJKCel3(L) )
+           CNST3=FLOAT( IJKCel3(M) )
            CNST5=(CF(M)-CF(L))/( CNST2 + CNST3 )
 
 !    Courant number in local size-1 cell, arithmetic average.
@@ -1152,7 +1155,7 @@
            IF( M .LE. 0) UFLX(i) = UC(L)*FTS
 
 !    Upstream cell length and gradient, depending on UFLX sign.
-           CNST1=FLOAT( IJKCel(3,K) )
+           CNST1=FLOAT( IJKCel3(K) )
            CNST4=(CF(L)-CF(K))/( CNST2 + CNST1 )
 
 !    Use minimum gradient all region.
@@ -1168,7 +1171,7 @@
            IF( L .LE. 0) UFLX(i) = UC(M)*FTS
 
 !    Upstream cell length and gradient, depending on UFLX sign.
-           CNST1=FLOAT( IJKCel(3,N) )
+           CNST1=FLOAT( IJKCel3(N) )
            CNST4=(CF(N)-CF(M))/( CNST1 + CNST3 )
 
 !    Use minimum gradient outside monotonic region. 
@@ -1199,7 +1202,7 @@
 !!Li        CALL SMCyUNO2(ivf, jvf, CQ, VCFL, VLCFLY, DNND, FVMD, FVDIFY, FMR)
 
          USE CONSTANTS
-         USE W3GDATMD, ONLY: NCel, MRFct, NVFc, IJKCel, IJKVFc, CLATF
+         USE W3GDATMD, ONLY: NCel, MRFct, NVFc, IJKCel, IJKVFc, CLATF, IJKCel4
          USE W3ODATMD, ONLY: NDSE, NDST
 
          IMPLICIT NONE
@@ -1235,8 +1238,8 @@
            N=IJKVFc(7,j)
 
 !    Face bounding cell lengths and gradient
-           CNST2=FLOAT( IJKCel(4,L) )
-           CNST3=FLOAT( IJKCel(4,M) )
+           CNST2=FLOAT( IJKCel4(L) )
+           CNST3=FLOAT( IJKCel4(M) )
            CNST5=(CF(M)-CF(L))/( CNST2 + CNST3 )
 
 !    Courant number in local size-1 cell unit 
@@ -1261,7 +1264,7 @@
            ENDIF
 
 !    Upstream cell size and irregular grid gradient, depending on VFLY.
-           CNST1=FLOAT( IJKCel(4,K) )
+           CNST1=FLOAT( IJKCel4(K) )
            CNST4=(CF(L)-CF(K))/( CNST2 + CNST1 )
 
 !    Use minimum gradient outside monotonic region
@@ -1282,7 +1285,7 @@
 
 !    Upstream cell size and gradient, depending on VFLY sign.
 !    Side gradients for central cell includs 0.5 factor.
-           CNST1=FLOAT( IJKCel(4,N) )
+           CNST1=FLOAT( IJKCel4(N) )
            CNST4=(CF(N)-CF(M))/( CNST1 + CNST3 )
 
 !    Use minimum gradient outside monotonic region
@@ -1315,6 +1318,7 @@
 
          USE CONSTANTS
          USE W3GDATMD, ONLY: NSEA, NY, NCel, NUFc, IJKCel, IJKUFc, CLATS
+         USE W3GDATMD, ONLY: IJKCel3
          USE W3ODATMD, ONLY: NDSE, NDST 
 
          IMPLICIT NONE
@@ -1346,8 +1350,8 @@
            N=IJKUFc(7,i)
 
 !    Face bounding cell lengths and gradient
-           CNST2=FLOAT( IJKCel(3,L) )
-           CNST3=FLOAT( IJKCel(3,M) )
+           CNST2=FLOAT( IJKCel3(L) )
+           CNST3=FLOAT( IJKCel3(M) )
            CNST5=(CF(M)-CF(L))
 
 !    Averaged Courant number for base-level cell face 
@@ -1502,6 +1506,7 @@
 
          USE CONSTANTS
          USE W3GDATMD, ONLY: NCel, MRFct, NUFc, IJKCel, IJKUFc, CLATS
+         USE W3GDATMD, ONLY: IJKCel3
          USE W3ODATMD, ONLY: NDSE, NDST 
 
          IMPLICIT NONE
@@ -1540,8 +1545,8 @@
            N=IJKUFc(7,i)
 
 !    Face bounding cell lengths and central gradient
-           CNST2=FLOAT( IJKCel(3,L) )
-           CNST3=FLOAT( IJKCel(3,M) )
+           CNST2=FLOAT( IJKCel3(L) )
+           CNST3=FLOAT( IJKCel3(M) )
            CNST5=(CF(M)-CF(L))/( CNST2 + CNST3 )
 
 !    Courant number in local size-1 cell, arithmetic average.
@@ -1564,7 +1569,7 @@
            IF( M .LE. 0) UFLX(i) = UC(L)*FTS
 
 !    Upstream cell length and gradient, depending on UFLX sign.
-           CNST1=FLOAT( IJKCel(3,K) )
+           CNST1=FLOAT( IJKCel3(K) )
            CNST4=(CF(L)-CF(K))/( CNST2 + CNST1 )
 
 !    Second order gradient
@@ -1595,7 +1600,7 @@
            IF( L .LE. 0) UFLX(i) = UC(M)*FTS
 
 !    Upstream cell length and gradient, depending on UFLX sign.
-           CNST1=FLOAT( IJKCel(3,N) )
+           CNST1=FLOAT( IJKCel3(N) )
            CNST4=(CF(N)-CF(M))/( CNST1 + CNST3 )
 
 !    Second order gradient
@@ -1642,6 +1647,7 @@
 
          USE CONSTANTS
          USE W3GDATMD, ONLY: NCel, MRFct, NVFc, IJKCel, IJKVFc, CLATF
+         USE W3GDATMD, ONLY: IJKCel4
          USE W3ODATMD, ONLY: NDSE, NDST
 
          IMPLICIT NONE
@@ -1678,8 +1684,8 @@
            N=IJKVFc(7,j)
 
 !    Face bounding cell lengths and gradient
-           CNST2=FLOAT( IJKCel(4,L) )
-           CNST3=FLOAT( IJKCel(4,M) )
+           CNST2=FLOAT( IJKCel4(L) )
+           CNST3=FLOAT( IJKCel4(M) )
            CNST5=(CF(M)-CF(L))/( CNST2 + CNST3 )
 
 !    Courant number in local size-1 cell unit 
@@ -1704,7 +1710,7 @@
            ENDIF
 
 !    Upstream cell size and irregular grid gradient, depending on VFLY.
-           CNST1=FLOAT( IJKCel(4,K) )
+           CNST1=FLOAT( IJKCel4(K) )
            CNST4=(CF(L)-CF(K))/( CNST2 + CNST1 )
 
 !    Second order gradient
@@ -1741,7 +1747,7 @@
 
 !    Upstream cell size and gradient, depending on VFLY sign.
 !    Side gradients for central cell includs 0.5 factor.
-           CNST1=FLOAT( IJKCel(4,N) )
+           CNST1=FLOAT( IJKCel4(N) )
            CNST4=(CF(N)-CF(M))/( CNST1 + CNST3 )
 
 !    Second order gradient
@@ -1790,6 +1796,7 @@
 
          USE CONSTANTS
          USE W3GDATMD, ONLY: NSEA, NY, NCel, NUFc, IJKCel, IJKUFc, CLATS
+         USE W3GDATMD, ONLY: IJKCel3
          USE W3ODATMD, ONLY: NDSE, NDST 
 
          IMPLICIT NONE
@@ -1821,8 +1828,8 @@
            N=IJKUFc(7,i)
 
 !    Face bounding cell lengths and gradient
-           CNST2=FLOAT( IJKCel(3,L) )
-           CNST3=FLOAT( IJKCel(3,M) )
+           CNST2=FLOAT( IJKCel3(L) )
+           CNST3=FLOAT( IJKCel3(M) )
            CNST5=(CF(M)-CF(L))
 
 !    Averaged Courant number for base-level cell face 
@@ -2203,6 +2210,7 @@
          USE CONSTANTS
          USE W3GDATMD, ONLY: NSEA,   NUFc,   NVFc,    &
       &                      IJKCel, IJKUFc, IJKVFC 
+         USE W3GDATMD, ONLY: IJKUFc5, IJKUFc6 
 !/ARC         USE W3GDATMD, ONLY:  NGLO
          USE W3ODATMD, ONLY: NDSE, NDST 
 
@@ -2235,8 +2243,8 @@
         DO i=1, NUFc
 
 !    Select Upstream, Central and Downstream cells
-           L=IJKUFc(5,i)
-           M=IJKUFc(6,i)
+           L=IJKUFc5(i)
+           M=IJKUFc6(i)
 
 !    Multi-resolution SMC grid requires flux multiplied by face factor.
            CNST5=Real( IJKUFc(3,i) )*(CVF(M)+CVF(L))


### PR DESCRIPTION
# Pull Request Summary
Added extra 1-dimension arrays with duplicated data for IJKUFc, IJKVFc, IJKCel, to make the data more contiguous, which can save memory bandwidth, achieve better performance.


## Description
The performance of SMC grid is limited by the memory bandwidth, because it needs to read 
the 2-dimension arrays IJKUFc, IJKVFc, IJKCel many times. 
In the loop, only 2 cells of the column (such as IJKCel(3,j), IJKCel(4,j)) are used, 
the pre-fetch on the other cells is wasted. 
So these arrays are kind of "AOS" (Array of Structure), I built some extra 1-dimension arrays
like "SOA" to make the data more contiguous, achieve better performance.

On the PRC NMEFC workloads, these changes can achieve 17% performance increasement. 

### Issue(s) addressed
* Is there an issue associated with this development (bug fix, enhancement, new feature)?    
This is an enhancement, I didn't open an issue before.
- fixes #<issue_number>
- fixes noaa-emc/ww3/issues/<issue_number>

### Check list  
* Is your feature branch up to date with the authoritative repository (NOAA/develop)?
* Make sure you have checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop), [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop) and [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number)
* Reviewers: @ukmo-jianguo-li 


### Testing
* How were these changes tested?
This has been tested on NMEFC's workload, and regtests/ww3_tp2.16, on Intel Icelake and Cascadelake platforms.

* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)
tested on ww3_tp2.16.

* If a new feature was added, was a new regression test added?
* Have regression tests been run?
Yes

* Which compiler / HPC you used to run the regression tests in the PR? 
On Intel ifort & mpiifort.

* Please provide the summary output of matrix.comp (_matrix.Diff.out_, _matrixCompFull.out_ and _matrixCompSummary.out_):    

Summary:
       ******************************************************
     ***  compare WAVEWATCH III matrix of regression tests  ***
       ******************************************************

base directory : /home/liuyun/WW3/regtests/
comp directory : /home/liuyun/Yun1Liu/WW3/regtests/
test(s)        :
ww3_tp2.16


**********************************************************************
********************* non-identical cases ****************************
**********************************************************************

**********************************************************************
************************ identical cases *****************************
**********************************************************************
ww3_tp2.16/./work

**********************************************************************
******************** summary of comparison ***************************
********** only results of non-identical cases are listed ************
****** if less than 10 files differ for a case, they are listed ******
**********************************************************************

Full:

       ******************************************************
     ***  compare WAVEWATCH III matrix of regression tests  ***
       ******************************************************

base directory : /home/liuyun/WW3/regtests/
comp directory : /home/liuyun/Yun1Liu/WW3/regtests/
test(s)        :
ww3_tp2.16


**********************************************************************
********************* non-identical cases ****************************
**********************************************************************

**********************************************************************
************************ identical cases *****************************
**********************************************************************
ww3_tp2.16/./work

**********************************************************************
******************* full output of comparison ************************
**********************************************************************

* test case: ww3_tp2.16; test run: ./work
*********************************************************
  found 36 files in base directory
  found 36 files in compare directory
     restart.ww3 are identical (binary)
     ww3.68060600.wnd are identical
     ww3.68060600.hs are identical
     ww3.68060600.t01 are identical
     ww3.68060603.wnd are identical
     ww3.68060603.hs are identical
     ww3.68060603.t01 are identical
     ww3.68060606.wnd are identical
     ww3.68060606.hs are identical
     ww3.68060606.t01 are identical
     ww3.68060609.wnd are identical
     ww3.68060609.hs are identical
     ww3.68060609.t01 are identical
     ww3.68060612.wnd are identical
     ww3.68060612.hs are identical
     ww3.68060612.t01 are identical
     ww3.68060615.wnd are identical
     ww3.68060615.hs are identical
     ww3.68060615.t01 are identical
     ww3.68060618.wnd are identical
     ww3.68060618.hs are identical
     ww3.68060618.t01 are identical
     ww3.68060621.wnd are identical
     ww3.68060621.hs are identical
     ww3.68060621.t01 are identical
     ww3.68060700.wnd are identical
     ww3.68060700.hs are identical
     ww3.68060700.t01 are identical
     ww3_grid.out are identical
     mod_def.ww3 are identical (binary)
     ww3_strt.out are identical
     skipped ww3_shel.out
     log.ww3 are identical (filtered)
     out_grd.ww3 are identical (binary)
     out_pnt.ww3 are identical (binary)
     ww3_outf.out are identical


Please indicate the expected changes in the outputs ([excluding the known list of non-identical tests](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-master#4-look-at-results)).